### PR TITLE
Fix Error: The method 'inheritFromWidgetOfExactType' isn't defined for the class 'BuildContext'.

### DIFF
--- a/lib/src/theme.dart
+++ b/lib/src/theme.dart
@@ -13,7 +13,7 @@ class LoadingTheme extends InheritedWidget {
 
   static LoadingThemeData of(BuildContext context) {
     final LoadingTheme result =
-        context.inheritFromWidgetOfExactType(LoadingTheme);
+        context.dependOnInheritedWidgetOfExactType<LoadingTheme>();
     return result?.data;
   }
 }


### PR DESCRIPTION
When i try to compile i get this error 

```
/C:/tools/flutter/.pub-cache/hosted/pub.dartlang.org/load-0.1.6/lib/src/theme.dart:16:17: Error: The method 'inheritFromWidgetOfExactType' isn't defined for the class 'BuildContext'.
 - 'BuildContext' is from 'package:flutter/src/widgets/framework.dart' ('/C:/tools/flutter/packages/flutter/lib/src/widgets/framework.dart').
Try correcting the name to the name of an existing method, or defining a method named 'inheritFromWidgetOfExactType'.
        context.inheritFromWidgetOfExactType(LoadingTheme);
```

Because in my version of flutter it's deleted.

I just replace inheritFromWidgetOfExactType by dependOnInheritedWidgetOfExactType recommended in flutter docs

https://api.flutter.dev/flutter/widgets/BuildContext/inheritFromWidgetOfExactType.html